### PR TITLE
Fix protection check for doorkeeper_for :except filters.

### DIFF
--- a/lib/grape-doorkeeper/oauth2.rb
+++ b/lib/grape-doorkeeper/oauth2.rb
@@ -16,7 +16,7 @@ module GrapeDoorkeeper
       
       if filter_options[:only]
         return filter_options[:only].include?( action.to_sym )
-      elsif filter_options[:only]
+      elsif filter_options[:except]
         return !filter_options[:except].include?( action.to_sym )     
       end
       


### PR DESCRIPTION
A typo prevent the authorization mechanism to work properly when `doorkeeper_for` is called with an `except` filter:

```
dorkeeper_for :all, except: [:foo]
```
