### PR TITLE
Avoid setting an incomplete header if scopes is nil.

### DIFF
--- a/lib/grape-doorkeeper/oauth2.rb
+++ b/lib/grape-doorkeeper/oauth2.rb
@@ -52,7 +52,7 @@ module GrapeDoorkeeper
               'Content-Type' => 'application/json',
               'X-Accepted-OAuth-Scopes' => scopes,
               'WWW-Authenticate' => "OAuth realm='#{options[:realm]}', error='#{error}'"
-            }
+            }.reject { |k,v| v.nil? }
     end
     
   end


### PR DESCRIPTION
Some application servers expect the hash to be well formed, at least Webrick
and Passenger require this fix to perform correcly.

This is related to #1
