### PR TITLE
Extract Grape::Middleware::Auth::OAuth2, which was deleted in grape 0.9

### DIFF
--- a/grape-doorkeeper.gemspec
+++ b/grape-doorkeeper.gemspec
@@ -14,12 +14,12 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "grape-doorkeeper"
 
-  s.add_runtime_dependency 'grape', '~> 0.6'
-  s.add_runtime_dependency 'doorkeeper', '~> 0'
+  s.add_runtime_dependency 'grape', '~> 0.9'
+  s.add_runtime_dependency 'doorkeeper', '~> 1.4.0'
     
   s.add_development_dependency 'rack-test', '~> 0'
   s.add_development_dependency 'rspec', '~> 2.9'
-  s.add_development_dependency 'bundler', '~> 0'
+  s.add_development_dependency 'bundler', '~> 1.7.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/grape-doorkeeper.rb
+++ b/lib/grape-doorkeeper.rb
@@ -1,5 +1,6 @@
 require 'grape'
 require 'doorkeeper'
+require 'grape-doorkeeper/grape_oauth2'
 require 'grape-doorkeeper/oauth2'
 
 module GrapeDoorkeeper

--- a/lib/grape-doorkeeper/grape_oauth2.rb
+++ b/lib/grape-doorkeeper/grape_oauth2.rb
@@ -1,0 +1,79 @@
+module GrapeDoorkeeper
+  # OAuth 2.0 authorization for Grape APIs.
+  class OAuth2Base < Grape::Middleware::Base
+    def default_options
+      {
+          token_class: 'AccessToken',
+          realm: 'OAuth API',
+          parameter: %w(bearer_token oauth_token access_token),
+          accepted_headers: %w(HTTP_AUTHORIZATION X_HTTP_AUTHORIZATION X-HTTP_AUTHORIZATION REDIRECT_X_HTTP_AUTHORIZATION),
+          header: [/Bearer (.*)/i, /OAuth (.*)/i],
+          required: true
+      }
+    end
+
+    def before
+      verify_token(token_parameter || token_header)
+    end
+
+    def request
+      @request ||= Grape::Request.new(env)
+    end
+
+    def params
+      @params ||= request.params
+    end
+
+    def token_parameter
+      Array(options[:parameter]).each do |p|
+        return params[p] if params[p]
+      end
+      nil
+    end
+
+    def token_header
+      return false unless authorization_header
+      Array(options[:header]).each do |regexp|
+        return $1 if authorization_header =~ regexp
+      end
+      nil
+    end
+
+    def authorization_header
+      options[:accepted_headers].each do |head|
+        return env[head] if env[head]
+      end
+      nil
+    end
+
+    def token_class
+      @klass ||= eval(options[:token_class]) # rubocop:disable Eval
+    end
+
+    def verify_token(token)
+      token = token_class.verify(token)
+      if token
+        if token.respond_to?(:expired?) && token.expired?
+          error_out(401, 'invalid_grant')
+        else
+          if !token.respond_to?(:permission_for?) || token.permission_for?(env)
+            env['api.token'] = token
+          else
+            error_out(403, 'insufficient_scope')
+          end
+        end
+      elsif !!options[:required]
+        error_out(401, 'invalid_grant')
+      end
+    end
+
+    def error_out(status, error)
+      throw :error,
+            message: error,
+            status: status,
+            headers: {
+                'WWW-Authenticate' => "OAuth realm='#{options[:realm]}', error='#{error}'"
+            }
+    end
+  end
+end

--- a/lib/grape-doorkeeper/oauth2.rb
+++ b/lib/grape-doorkeeper/oauth2.rb
@@ -3,7 +3,7 @@ require 'doorkeeper/doorkeeper_for'
 module GrapeDoorkeeper
   # OAuth 2.0 authorization for Grape APIs.
   
-  class Middleware < Grape::Middleware::Auth::OAuth2
+  class Middleware < GrapeDoorkeeper::OAuth2Base
   
     def protected_endpoint?
       endpoint = env['api.endpoint']


### PR DESCRIPTION
According to https://github.com/intridea/grape/blob/master/UPGRADING.md

Grape::Middleware::Auth::OAuth2 have been removed and current grape-doorkeeper version does not compatible with newest Grape 0.9 version.

Just extract Grape::Middleware::Auth::OAuth2

And fix gemspec file
